### PR TITLE
fix: remove model_id from MLmodel files during import to fix get_model_info

### DIFF
--- a/mlflow_migration/run/import_run.py
+++ b/mlflow_migration/run/import_run.py
@@ -93,7 +93,7 @@ def import_run(
         if os.path.exists(path):
             mlflow_client.log_artifacts(run_id, path)
         if mlmodel_fix:
-            run_utils.update_mlmodel_run_id(mlflow_client, run_id)
+            run_utils.update_mlmodel_fields(mlflow_client, run_id)
         mlflow_client.set_terminated(run_id, RunStatus.to_string(RunStatus.FINISHED))
         run = mlflow_client.get_run(run_id)
         if src_run_dct["info"]["lifecycle_stage"] == LifecycleStage.DELETED:


### PR DESCRIPTION
In MLflow 3.x, MLmodel files contain a model_id field that references a LoggedModel entity on the source server. After import, get_model_info() fails with "LoggedModel not found" because the ID doesnt exist on the target server.
                                                                                                                                                                              Changes:
  - Rename update_mlmodel_run_id() to update_mlmodel_fields()
  - Remove model_id field from MLmodel files during import
  - Add unit tests for model_id removal functionality

 MLflow gracefully handles missing model_id, so models remain fully functional for loading and inference after this fix.